### PR TITLE
Allow dependabot to upgrade Python dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,8 @@ updates:
     schedule:
       interval: daily
       time: "06:00"
+  - package-ecosystem: "pip"
+    directory: "/appdaemon"
+    schedule:
+      interval: daily
+      time: "06:00"


### PR DESCRIPTION
# Proposed Changes

Allow dependabot to upgrade the appdaemon Python dependencies, so we stay up 2 date 👍 