### PR TITLE
Upgrade add-on base image to 9.1.0

### DIFF
--- a/appdaemon/Dockerfile
+++ b/appdaemon/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base:8.0.6
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -16,20 +16,21 @@ ARG BUILD_ARCH=amd64
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        gcc=9.3.0-r2 \
+        gcc=10.2.1_pre1-r3 \
         libc-dev=0.7.2-r3 \
         libffi-dev=3.3-r2 \
+        openssl-dev=1.1.1i-r0 \
         patch=2.7.6-r6 \
-        python3-dev=3.8.5-r0 \
+        python3-dev=3.8.7-r0 \
     \
     && apk add --no-cache \
-        py3-pip=20.1.1-r0 \
-        python3=3.8.5-r0 \
+        py3-pip=20.3.3-r0 \
+        python3=3.8.7-r0 \
     \
     && pip install \
         --no-cache-dir \
         --prefer-binary \
-        --find-links "https://wheels.home-assistant.io/alpine-3.12/${BUILD_ARCH}/" \
+        --find-links "https://wheels.home-assistant.io/alpine-3.13/${BUILD_ARCH}/" \
         -r /tmp/requirements.txt \
     \
     && cd /usr/lib/python3.8/site-packages/ \

--- a/appdaemon/build.json
+++ b/appdaemon/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "hassioaddons/base-aarch64:8.0.6",
-    "amd64": "hassioaddons/base-amd64:8.0.6",
-    "armhf": "hassioaddons/base-armhf:8.0.6",
-    "armv7": "hassioaddons/base-armv7:8.0.6",
-    "i386": "hassioaddons/base-i386:8.0.6"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.0",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.0",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.0",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.0",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.1.0"
   }
 }

--- a/appdaemon/config.json
+++ b/appdaemon/config.json
@@ -7,7 +7,6 @@
   "webui": "http://[HOST]:[PORT:5050]",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "init": false,
-  "hassio_api": true,
   "homeassistant_api": true,
   "auto_uart": true,
   "ports": {

--- a/appdaemon/rootfs/etc/cont-init.d/appdaemon.sh
+++ b/appdaemon/rootfs/etc/cont-init.d/appdaemon.sh
@@ -28,7 +28,7 @@ if bashio::config.has_value 'python_packages'; then
     for package in $(bashio::config 'python_packages'); do
         pip3 install \
             --prefer-binary \
-            --find-links "https://wheels.home-assistant.io/alpine-3.12/${arch}/" \
+            --find-links "https://wheels.home-assistant.io/alpine-3.13/${arch}/" \
             "$package" \
                 || bashio::exit.nok "Failed installing package ${package}"
     done


### PR DESCRIPTION
# Proposed Changes

Upgrade the add-on base image to the latest and greatest, including an updated Python and removal of Supervisor API access (no longer needed).