### PR TITLE
Raise fatal error message on missing AppDaemon configuration file

### DIFF
--- a/appdaemon/rootfs/etc/cont-init.d/appdaemon.sh
+++ b/appdaemon/rootfs/etc/cont-init.d/appdaemon.sh
@@ -5,6 +5,22 @@
 # ==============================================================================
 declare arch
 
+# Raise warning if the directory exists, but the appdaemon config is missing.
+if bashio::fs.directory_exists '/config/appdaemon'; then
+    if ! bashio::fs.file_exists '/config/appdaemon/appdaemon.yaml'; then
+        bashio::log.fatal
+        bashio::log.fatal "Seems like the /config/appdaemon folder exists,"
+        bashio::log.fatal "however appdaemon.yaml wasn't found."
+        bashio::log.fatal
+        bashio::log.fatal "Remove or rename the /config/appdaemon folder"
+        bashio::log.fatal "and the add-on will create a new and fresh one"
+        bashio::log.fatal "for you."
+        bashio::log.fatal
+
+        bashio::exit.nok
+    fi
+fi
+
 # Creates initial AppDaemon configuration in case it is non-existing
 if ! bashio::fs.directory_exists '/config/appdaemon'; then
     cp -R /root/appdaemon /config/appdaemon \

--- a/appdaemon/rootfs/etc/cont-init.d/appdaemon.sh
+++ b/appdaemon/rootfs/etc/cont-init.d/appdaemon.sh
@@ -5,26 +5,24 @@
 # ==============================================================================
 declare arch
 
-# Raise warning if the directory exists, but the appdaemon config is missing.
-if bashio::fs.directory_exists '/config/appdaemon'; then
-    if ! bashio::fs.file_exists '/config/appdaemon/appdaemon.yaml'; then
-        bashio::log.fatal
-        bashio::log.fatal "Seems like the /config/appdaemon folder exists,"
-        bashio::log.fatal "however appdaemon.yaml wasn't found."
-        bashio::log.fatal
-        bashio::log.fatal "Remove or rename the /config/appdaemon folder"
-        bashio::log.fatal "and the add-on will create a new and fresh one"
-        bashio::log.fatal "for you."
-        bashio::log.fatal
-
-        bashio::exit.nok
-    fi
-fi
-
 # Creates initial AppDaemon configuration in case it is non-existing
 if ! bashio::fs.directory_exists '/config/appdaemon'; then
     cp -R /root/appdaemon /config/appdaemon \
         || bashio::exit.nok 'Failed to create initial AppDaemon configuration'
+fi
+
+# Raise warning if the directory exists, but the appdaemon config is missing.
+if ! bashio::fs.file_exists '/config/appdaemon/appdaemon.yaml'; then
+    bashio::log.fatal
+    bashio::log.fatal "Seems like the /config/appdaemon folder exists,"
+    bashio::log.fatal "however appdaemon.yaml wasn't found."
+    bashio::log.fatal
+    bashio::log.fatal "Remove or rename the /config/appdaemon folder"
+    bashio::log.fatal "and the add-on will create a new and fresh one"
+    bashio::log.fatal "for you."
+    bashio::log.fatal
+
+    bashio::exit.nok
 fi
 
 # Install user configured/requested packages


### PR DESCRIPTION
# Proposed Changes

To prevent questions like these:

![image](https://user-images.githubusercontent.com/195327/106624185-ae03dd80-6575-11eb-978f-086aa62ebba2.png)

The add-on will now just crash and burn with a proper error message when this happens.