### PR TITLE
Patch AppDaemon 4.0.6 for Supervisor compatibility

### DIFF
--- a/appdaemon/rootfs/patches/hassio.patch
+++ b/appdaemon/rootfs/patches/hassio.patch
@@ -1,9 +1,8 @@
 diff --git a/appdaemon/plugins/hass/hassplugin.py b/appdaemon/plugins/hass/hassplugin.py
-index 138aa4d..755659a 100644
+index 702d0f14..be41de18 100644
 --- a/appdaemon/plugins/hass/hassplugin.py
 +++ b/appdaemon/plugins/hass/hassplugin.py
-@@ -8,6 +8,7 @@ import pytz
- from deepdiff import DeepDiff
+@@ -9,6 +9,7 @@ from deepdiff import DeepDiff
  import datetime
  from urllib.parse import quote
  from urllib.parse import urlencode
@@ -11,7 +10,7 @@ index 138aa4d..755659a 100644
  
  import appdaemon.utils as utils
  from appdaemon.appdaemon import AppDaemon
-@@ -64,11 +65,17 @@ class HassPlugin(PluginBase):
+@@ -63,11 +64,17 @@ class HassPlugin(PluginBase):
  
          if "token" in args:
              self.token = args["token"]


### PR DESCRIPTION
# Proposed Changes

Updates hotfixes/patches done with AppDaemon to be compatible with AppDaemon 4.0.6.
These patches make AppDaemon compatible / allow AppDaemon to seamlessly integrate with Supervisor based installations.