### PR TITLE
docs: fix failing example

### DIFF
--- a/appdaemon/DOCS.md
+++ b/appdaemon/DOCS.md
@@ -33,9 +33,9 @@ Example add-on configuration:
 log_level: info
 system_packages:
   - ffmpeg
+  - py3-pillow
 python_packages:
   - PyMySQL
-  - Pillow
 ```
 
 **Note**: _This is just an example, don't copy and past it! Create your own!_
@@ -63,7 +63,8 @@ These log level also affects the log levels of the AppDaemon.
 ### Option: `system_packages`
 
 Allows you to specify additional [Alpine packages][alpine-packages] to be
-installed to your AppDaemon setup (e.g., `g++`. `make`, `ffmpeg`).
+installed to your AppDaemon setup (e.g., `g++`. `make`, `ffmpeg`, `py3-numpy`,
+`py3-pillow`).
 
 **Note**: _Adding many packages will result in a longer start-up time
 for the add-on._
@@ -71,7 +72,7 @@ for the add-on._
 ### Option: `python_packages`
 
 Allows you to specify additional [Python packages][python-packages] to be
-installed to your AppDaemon setup (e.g., `PyMySQL`. `Requests`, `Pillow`).
+installed to your AppDaemon setup (e.g., `PyMySQL`. `Requests`).
 
 **Note**: _Adding many packages will result in a longer start-up time
 for the add-on._


### PR DESCRIPTION
Hi there,

Since the last addon update, numpy and pillow (maybe others) seemed to be broken when installed through pip. See here:

- https://community.home-assistant.io/t/using-pillow-with-appdaemon4/335884
- https://community.home-assistant.io/t/issue-with-numpy/332610

It seems that this latest image is giving problems with Python C extension libraries. For example, this used to work:

```yaml
system_packages: []
python_packages: [Pillow]
init_commands: [python3 -c 'from PIL import Image']
```

Now this needs to be translated to:

```yaml
system_packages: [py3-pillow]
python_packages: []
init_commands: [python3 -c 'from PIL import Image']
```

The same happens with Numpy.

# Proposed Changes

This PR suggests changing the `Pillow` from python package to system package  (`py3-pillow`). I totally understand this is just a documentation example, but in my opinion, it makes more sense to have a working example rather than a broken one.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/

Regards,
Xavi M.
