### PR TITLE
Fix incorrect wheels repository for additional Python packages

### DIFF
--- a/appdaemon/rootfs/etc/cont-init.d/appdaemon.sh
+++ b/appdaemon/rootfs/etc/cont-init.d/appdaemon.sh
@@ -42,7 +42,7 @@ if bashio::config.has_value 'python_packages'; then
     for package in $(bashio::config 'python_packages'); do
         pip3 install \
             --prefer-binary \
-            --find-links "https://wheels.home-assistant.io/alpine-3.13/${arch}/" \
+            --find-links "https://wheels.home-assistant.io/alpine-3.14/${arch}/" \
             "$package" \
                 || bashio::exit.nok "Failed installing package ${package}"
     done


### PR DESCRIPTION
# Proposed Changes

Fixes an incorrect Python wheels repository being used.

Revealed by the logs here: <https://github.com/hassio-addons/addon-appdaemon/issues/180#issuecomment-1002953727>
