### PR TITLE
:hammer: Rename add-on to just 'AppDaemon'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: AppDaemon 4
+# Home Assistant Community Add-on: AppDaemon
 
 [![GitHub Release][releases-shield]][releases]
 ![Project Stage][project-stage-shield]
@@ -27,10 +27,10 @@ Python Apps and HADashboard for Home Assistant
 
 ## About
 
-AppDaemon is a loosely coupled, multithreaded, sandboxed python execution
-environment for writing automation apps for Home Assistant home automation
-software. It also provides a configurable dashboard (HADashboard) suitable
-for wall mounted tablets.
+[AppDaemon][appdaemon] is a loosely coupled, multithreaded, sandboxed Python
+execution environment for writing automation apps for Home Assistant home
+automation software. It also provides a configurable dashboard (HADashboard)
+suitable for wall mounted tablets.
 
 [:books: Read the full add-on documentation][docs]
 
@@ -99,6 +99,7 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
+[appdaemon]: https://appdaemon.readthedocs.io
 [armhf-shield]: https://img.shields.io/badge/armhf-yes-green.svg
 [armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-appdaemon.svg

--- a/appdaemon/.README.j2
+++ b/appdaemon/.README.j2
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: AppDaemon 4
+# Home Assistant Community Add-on: AppDaemon
 
 [![Release][release-shield]][release] ![Project Stage][project-stage-shield] ![Project Maintenance][maintenance-shield]
 
@@ -12,10 +12,10 @@ Python Apps and HADashboard for Home Assistant
 
 ## About
 
-AppDaemon is a loosely coupled, multithreaded, sandboxed python execution
-environment for writing automation apps for Home Assistant home automation
-software. It also provides a configurable dashboard (HADashboard) suitable
-for wall mounted tablets.
+[AppDaemon][appdaemon] is a loosely coupled, multithreaded, sandboxed Python
+execution environment for writing automation apps for Home Assistant home
+automation software. It also provides a configurable dashboard (HADashboard)
+suitable for wall mounted tablets.
 
 ![HADashboard screenshot][screenshot]
 
@@ -58,6 +58,7 @@ If you are more interested in stable releases of our add-ons:
 <https://github.com/hassio-addons/repository>
 
 {% endif %}
+[appdaemon]: https://appdaemon.readthedocs.io
 [discord-shield]: https://img.shields.io/discord/478094546522079232.svg
 [discord]: https://discord.me/hassioaddons
 [forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg

--- a/appdaemon/DOCS.md
+++ b/appdaemon/DOCS.md
@@ -1,9 +1,9 @@
-# Home Assistant Community Add-on: AppDaemon 4
+# Home Assistant Community Add-on: AppDaemon
 
-AppDaemon is a loosely coupled, multithreaded, sandboxed python execution
-environment for writing automation apps for Home Assistant home automation
-software. It also provides a configurable dashboard (HADashboard) suitable
-for wall mounted tablets.
+[AppDaemon][appdaemon] is a loosely coupled, multithreaded, sandboxed Python
+execution environment for writing automation apps for Home Assistant home
+automation software. It also provides a configurable dashboard (HADashboard)
+suitable for wall mounted tablets.
 
 ## Installation
 
@@ -16,8 +16,8 @@ comparison to installing any other Home Assistant add-on.
    [![Open this add-on in your Home Assistant instance.][addon-badge]][addon]
 
 1. Click the "Install" button to install the add-on.
-1. Start the "AppDaemon 4" add-on
-1. Check the logs of the "AppDaemon 4" add-on to see if everything went well.
+1. Start the "AppDaemon" add-on
+1. Check the logs of the "AppDaemon" add-on to see if everything went well.
 
 :information_source: Please note, the add-on is pre-configured to connect with
 Home Assistant. There is no need to create access tokens or to set your
@@ -120,45 +120,6 @@ official documentation. The official documentation will state `ha_url` and
 
 However, you are free to set them if you want to override, however, in
 general usage, that should not be needed and is not recommended for this add-on.
-
-## Upgrading from AppDaemon 3.x
-
-If you have previously ran AppDaemon 3.x (e.g., via an add-on), these steps
-will help you getting upgraded to AppDaemon 4.x.
-
-- After installing this add-on, stop the current running AppDaemon 3.x add-on.
-- Open your `/config/appdaemon/appdaemon.yaml` file in an editor.
-  - Remove the `log`.
-  - Remove`threads`, `api_port`, `app_dir`, `ha_url` and `token`.
-  - Add the following to the `appdaemon` section: `latitude`, `longitude`,
-    `elevation` and `time_zone`.
-  - Add a `http` section with `url: http://127.0.0.1:5050` in it.
-  - At the end of the file add `admin:` and `api:`.
-  - Remove everthing under `hadashboard:`, leaving just that.
-
-The result should look something like this:
-
-```yaml
----
-secrets: /config/secrets.yaml
-appdaemon:
-  latitude: 52.379189
-  longitude: 4.899431
-  elevation: 2
-  time_zone: Europe/Amsterdam
-  plugins:
-    HASS:
-      type: hass
-http:
-  url: http://127.0.0.1:5050
-hadashboard:
-admin:
-api:
-```
-
-Be sure to check the "Upgrading from 3.x" on the AppDaemon website:
-
-<https://appdaemon.readthedocs.io/en/latest/UPGRADE_FROM_3.x.html>
 
 ## Changelog & Releases
 

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,5 +1,5 @@
 ---
-name: AppDaemon 4
+name: AppDaemon
 version: dev
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant


### PR DESCRIPTION
# Proposed Changes

Renames the add-on to just "AppDaemon".

AppDeamon 3 is now long enough out of the picture to allow for it.
For that reason, the documentation is also adjusted to remove the migration guide.
