### PR TITLE
✨ Add access to media folder

### DIFF
--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -22,6 +22,7 @@ ports_description:
 map:
   - config:rw
   - share:rw
+  - media:rw
   - ssl
 options:
   system_packages: []


### PR DESCRIPTION
# Proposed Changes

The change adds mapping of `media` volume for AppDaemon so that it's able to manipulate content stored there.

I'm reading some images from external systems with an AppDaemon app, process them and then store them in media volume for usage through Home Assistant (for example you can cast the result to a display).
