### PR TITLE
Cache system/python packages

### DIFF
--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -27,21 +27,48 @@ fi
 
 # Install user configured/requested packages
 if bashio::config.has_value 'system_packages'; then
-    apk update \
-        || bashio::exit.nok 'Failed updating Alpine packages repository indexes'
+    # Check if cache is available and tagged with the exact same addon version and list of packages
+    packages=$(bashio::config 'system_packages')
+    cache=/data/package-cache/apk/
+    tag="addon-version: $(bashio::addon.version) packages: $packages"
 
-    for package in $(bashio::config 'system_packages'); do
-        apk add "$package" \
-            || bashio::exit.nok "Failed installing package ${package}"
-    done
+    if [ ! -f $cache/tag ] || [ "$tag" != "$(cat $cache/tag)" ]; then
+        # Cache not available or wrongly tagged. Re-create it.
+        rm -rf $cache && mkdir -p $cache && cd $cache
+        apk update \
+            || bashio::exit.nok 'Failed updating Alpine packages repository indexes'
+        apk fetch -R $packages \
+            || bashio::exit.nok "Failed downloading packages ${packages}"
+        printf "%s" "$tag" > tag      # store the tag
+    fi
+
+    # Install packages from cache.
+    apk add --no-network $cache/*.apk \
+        || (rm -rf $cache;        # delete cache in case of error
+            bashio::exit.nok "Failed installing packages ${packages}")
 fi
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then
-    for package in $(bashio::config 'python_packages'); do
-        pip3 install "$package" \
-            || bashio::exit.nok "Failed installing package ${package}"
-    done
+
+    # Check if cache is available and tagged with the exact same addon version and list of packages
+    packages=$(bashio::config 'python_packages')
+    cache=/data/package-cache/pip/
+    tag="addon-version: $(bashio::addon.version) packages: $packages"
+
+    if [ ! -f $cache/tag ] || [ "$tag" != "$(cat $cache/tag)" ]; then
+        # Cache not available or wrongly tagged. Re-create it.
+        rm -rf $cache && mkdir -p $cache && cd $cache
+        pip download $packages \
+            || bashio::exit.nok "Failed downloading packages ${packages}"
+        printf "%s" "$tag" > tag      # store the tag
+    fi
+
+    # Install packages from cache.
+    # HA sets its own PIP_FIND_LINKS, so we need to replace it! (instead of using --find-links)
+    PIP_FIND_LINKS=$cache pip install --no-index $packages \
+        || (rm -rf $cache;        # delete cache in case of error
+            bashio::exit.nok "Failed installing packages ${packages}")
 fi
 
 # Executes user configured/requested commands on startup


### PR DESCRIPTION
# Proposed Changes

The AppDaemon addon re-installs user-configured system and python packages on every restart. Apart from being slow, this has the serious drawback of completely breaking the setup if no internet connection is available (going completely against the HA philosophy).

With this PR package installation happens in two phases:
1. Packages with their dependencies are downloaded into `/data/package-cache/{apk,pip}` using `apk fetch` and `pip download`.
2. Packages are installed from the cache.

The first step is skipped if the cache already exists, so future restarts are fast and require no internet connection.

To increase robustness:
1. The cache is tagged with the exact addon version and package list (file `/data/package-cache/{apk,pip}/tag`). So if the addon is upgraded, or the package list changes, the full cache is rebuilt, avoiding issues with old cached packages.
2. If the installation fails the cache is cleared, to allow recovering from errors.


## Related Issues

#235 #216 