### PR TITLE
Add auto-install system and pip packages

### DIFF
--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.1
+version: dev.2
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.19
+version: dev.20
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.22
+version: dev.23
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,9 +1,9 @@
 ---
 name: AppDaemon
-version: dev
+version: dev.1
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
-url: https://github.com/hassio-addons/addon-appdaemon
+url: https://github.com/AlexMKX/addon-appdaemon
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:5050]
 arch:

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.30
+version: dev.31
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.24
+version: dev.25
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.32
+version: dev.33
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.31
+version: dev.32
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.10
+version: dev.11
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.9
+version: dev.10
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.23
+version: dev.24
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.17
+version: dev.18
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.2
+version: dev.e
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,9 +1,9 @@
 ---
 name: AppDaemon
-version: dev.35
+version: dev
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
-url: https://github.com/AlexMKX/addon-appdaemon
+url: https://github.com/hassio-addons/addon-appdaemon
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:5050]
 arch:

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.11
+version: dev.12
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.16
+version: dev.17
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.34
+version: dev.35
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.15
+version: dev.16
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.4
+version: dev.5
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.33
+version: dev.34
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.14
+version: dev.15
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev
+version: dev.1
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.7
+version: dev.8
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.3
+version: dev.4
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.18
+version: dev.19
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.27
+version: dev.28
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.12
+version: dev.13
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.e
+version: dev.3
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.28
+version: dev.29
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.13
+version: dev.14
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.26
+version: dev.27
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.8
+version: dev.9
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.5
+version: dev.6
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.6
+version: dev.7
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.29
+version: dev.30
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.25
+version: dev.26
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.20
+version: dev.21
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -3,7 +3,7 @@ name: AppDaemon
 version: dev
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
-url: https://github.com/hassio-addons/addon-appdaemon
+url: https://github.com/AlexMKX/addon-appdaemon
 codenotary: codenotary@frenck.dev
 webui: http://[HOST]:[PORT:5050]
 arch:

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: AppDaemon
-version: dev.21
+version: dev.22
 slug: appdaemon
 description: Python Apps and Dashboard using AppDaemon 4.x for Home Assistant
 url: https://github.com/AlexMKX/addon-appdaemon

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -37,7 +37,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 #mkdir -p /share/appdaemon/apk.cache
 #ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add {} \;
 
 
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -37,9 +37,9 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
 
-export XDG_CACHE_HOME=/config/appdaemon/cache
+
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt
-find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 install --upgrade -r {} \;
+find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 --cache-dir /config/appdaemon/cache install --upgrade -r {} \;
 
 # Run the AppDaemon
 exec appdaemon -c /config/appdaemon -D "${log_level}"

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -6,7 +6,7 @@
 # ==============================================================================
 declare log_level
 
-bashio::log.info "Starting AppDaemon2..."
+bashio::log.info "Starting AppDaemon3..."
 
 # Find the matching Tor log level
 log_level="INFO"
@@ -39,7 +39,8 @@ find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {
 
 
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt
-find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 --cache-dir /config/appdaemon/cache install --upgrade -r {} \;
+mkdir -p /share/appdaemon/pip.cache
+find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 --cache-dir /share/appdaemon/pip.cache install --upgrade -r {} \;
 
 # Run the AppDaemon
 exec appdaemon -c /config/appdaemon -D "${log_level}"

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -35,6 +35,8 @@ fi
 # - Use cat to read all the file contents, use echo to append whtespace " " char to the file content (to guard against the corner case where the user does not put a newline after the package name)
 # - Use tr to substitute all newlines with " " char, to concatenate the name of all packages in a single line
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
+mkdir -p /share/appdaemon/apk.cache
+ln -s /share/appdaemon/apk.cache /etc/apk/cache
 find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
 
 

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -23,7 +23,7 @@ if bashio::config.has_value 'log_level'; then
             ;;
         error)
             log_level="ERROR"
-            ;;
+            ;;e
         fatal|off)
             log_level="FATAL"
             ;;
@@ -32,9 +32,6 @@ fi
 
 
 
-# Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt
-mkdir -p /share/appdaemon/pip.cache
-find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 --cache-dir /share/appdaemon/pip.cache install --upgrade -r {} \;
 
 # Run the AppDaemon
 exec appdaemon -c /config/appdaemon -D "${log_level}"

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -30,14 +30,6 @@ if bashio::config.has_value 'log_level'; then
     esac
 fi
 
-# Install packages specified by the end-user.
-# - Recusively traverse $CONF directory, searching for non-empty system_packages.txt files
-# - Use cat to read all the file contents, use echo to append whtespace " " char to the file content (to guard against the corner case where the user does not put a newline after the package name)
-# - Use tr to substitute all newlines with " " char, to concatenate the name of all packages in a single line
-# - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
-#mkdir -p /share/appdaemon/apk.cache
-#ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk -vv add
 
 
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -37,7 +37,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
 
-export XDG_CACHE_HOME=/tmp/pip.cache
+export XDG_CACHE_HOME=/config/appdaemon/cache
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt
 find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 install --upgrade -r {} \;
 

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -37,7 +37,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 #mkdir -p /share/appdaemon/apk.cache
 #ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add --update --no-cache
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk -vv add
 
 
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -35,8 +35,8 @@ fi
 # - Use cat to read all the file contents, use echo to append whtespace " " char to the file content (to guard against the corner case where the user does not put a newline after the package name)
 # - Use tr to substitute all newlines with " " char, to concatenate the name of all packages in a single line
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
-mkdir -p /share/appdaemon/apk.cache
-ln -s /share/appdaemon/apk.cache /etc/apk/cache
+#mkdir -p /share/appdaemon/apk.cache
+#ln -s /share/appdaemon/apk.cache /etc/apk/cache
 find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
 
 

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -23,7 +23,7 @@ if bashio::config.has_value 'log_level'; then
             ;;
         error)
             log_level="ERROR"
-            ;;e
+            ;;
         fatal|off)
             log_level="FATAL"
             ;;

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -37,7 +37,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 #mkdir -p /share/appdaemon/apk.cache
 #ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add --update --no-cache
 
 
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -37,6 +37,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
 
+export XDG_CACHE_HOME=/tmp/pip.cache
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt
 find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 install --upgrade -r {} \;
 

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -6,7 +6,7 @@
 # ==============================================================================
 declare log_level
 
-bashio::log.info "Starting AppDaemon..."
+bashio::log.info "Starting AppDaemon2..."
 
 # Find the matching Tor log level
 log_level="INFO"
@@ -29,6 +29,16 @@ if bashio::config.has_value 'log_level'; then
             ;;
     esac
 fi
+
+# Install packages specified by the end-user.
+# - Recusively traverse $CONF directory, searching for non-empty system_packages.txt files
+# - Use cat to read all the file contents, use echo to append whtespace " " char to the file content (to guard against the corner case where the user does not put a newline after the package name)
+# - Use tr to substitute all newlines with " " char, to concatenate the name of all packages in a single line
+# - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
+
+# Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt
+find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 install --upgrade -r {} \;
 
 # Run the AppDaemon
 exec appdaemon -c /config/appdaemon -D "${log_level}"

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -37,7 +37,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 #mkdir -p /share/appdaemon/apk.cache
 #ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add {} \;
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk add
 
 
 # Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -6,7 +6,7 @@
 # ==============================================================================
 declare log_level
 
-bashio::log.info "Starting AppDaemon3..."
+bashio::log.info "Starting AppDaemon..."
 
 # Find the matching Tor log level
 log_level="INFO"
@@ -29,9 +29,6 @@ if bashio::config.has_value 'log_level'; then
             ;;
     esac
 fi
-
-
-
 
 # Run the AppDaemon
 exec appdaemon -c /config/appdaemon -D "${log_level}"

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g' | xargs -n 1 -0 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;$!ba;s/\n/ /g" | xargs -n 1 -0 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -47,6 +47,10 @@ ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
 find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr -d '\xEF\xBB\xBF' | sed ':a;N;$!ba;s/\n/ /g' | xargs -n 1 -r -t apk add
 
+# Check recursively under $CONF directory for additional python dependencies defined by the end-user via requirements.txt
+mkdir -p /share/appdaemon/pip.cache
+find /config/appdaemon -name requirements.txt -type f -not -empty -exec pip3 --cache-dir /share/appdaemon/pip.cache install --upgrade -r {} \;
+
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then
     for package in $(bashio::config 'python_packages'); do

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -L 1 -I {} -t --no-run-if-empty bash -c apk add {}
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -n 1 -I {} -t --no-run-if-empty bash -c apk add {}
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,12 +43,9 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-packages=`find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g'`
-for p in $packages;
-do
-    apk add "$p"
-done
+packages=`find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\040/g'` | xargs -n 1 -r hexdump
 
+packages=`find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\040/g'` | xargs -n 1 -r apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;\$!ba;s/\\n/ /g" | xargs -n 1 -0 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;\$!ba;s/\\n/\\x20/g" | xargs -n 1 -0 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -I {} -t --no-run-if-empty apk add "{}"
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -L 1 -I {} -t --no-run-if-empty bash -c apk add {}
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;\$!ba;s/\\n/\\x20/g" | xargs -n 1 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;\$!ba;s/\\n/ /g" | xargs -n 1 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -46,7 +46,7 @@ ln -s /share/appdaemon/apk.cache /etc/apk/cache
 packages=`find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g'`
 for p in $packages;
 do
-    apk add $p
+    apk add "$p"
 done
 
 

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;$!ba;s/\n/ /g" | xargs -n 1 -0 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;\$!ba;s/\\n/ /g" | xargs -n 1 -0 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -36,6 +36,16 @@ if bashio::config.has_value 'system_packages'; then
     done
 fi
 
+# Install packages specified by the end-user.
+# - Recusively traverse $CONF directory, searching for non-empty system_packages.txt files
+# - Use cat to read all the file contents, use echo to append whtespace " " char to the file content (to guard against the corner case where the user does not put a newline after the package name)
+# - Use tr to substitute all newlines with " " char, to concatenate the name of all packages in a single line
+# - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
+mkdir -p /share/appdaemon/apk.cache
+ln -s /share/appdaemon/apk.cache /etc/apk/cache
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk -vv add
+
+
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then
     for package in $(bashio::config 'python_packages'); do

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,9 +43,9 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\040/g' | xargs -n 1 -r hexdump
+#find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\0/g' | xargs -n 1 -r hexdump
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\040/g' | xargs -n 1 -r apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\0/g' | xargs -n 1 -r apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -n 1 -I {} -t --no-run-if-empty apk add "{}"
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -d " " -n 1 -I {} -t --no-run-if-empty apk add "{}"
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,8 +43,11 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g' | xargs -0 -n 1 -I {} -t --no-run-if-empty apk add "{}"
-#echo py3-psycopg2 | xargs apk add
+packages=`find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g'`
+for p in $packages;
+do
+    apk add $p
+done
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,8 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -0 -n 1 -I {} -t --no-run-if-empty apk add "{}"
+#find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -0 -n 1 -I {} -t --no-run-if-empty apk add "{}"
+echo py3-psycopg2 | xargs apk add
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed 's/\n/ /' | xargs -0 -n 1 -I {} -t --no-run-if-empty echo "{}"
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g' | xargs -0 -n 1 -I {} -t --no-run-if-empty echo "{}"
 #echo py3-psycopg2 | xargs apk add
 
 

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\0/g' | xargs -n 1 -0 -r apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g' | xargs -n 1 -0 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 #find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty 
-apk -vv add "py3-psycopg2"
+apk -vv add py3-psycopg2
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -d " " -n 1 -I {} -t --no-run-if-empty apk add "{}"
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -0 -n 1 -I {} -t --no-run-if-empty apk add "{}"
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | dos2unix -u | sed ":a;N;\$!ba;s/\\n/ /g" | xargs -n 1 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed '1s/^\\xEF\\xBB\\xBF//' | sed ':a;N;\$!ba;s/\n/ /g' | xargs -n 1 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,8 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-#find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty 
-apk -vv add py3-psycopg2
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -I {} -t --no-run-if-empty echo "{}"
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;\$!ba;s/\\n/ /g" | xargs -n 1 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | dos2unix -u | sed ":a;N;\$!ba;s/\\n/ /g" | xargs -n 1 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -39,12 +39,13 @@ fi
 # Install packages specified by the end-user.
 # - Recusively traverse apps directory, searching for non-empty system_packages.txt files
 # - Use cat to read all the file contents, use echo to append whtespace " " char to the file content (to guard against the corner case where the user does not put a newline after the package name)
-# - Use tr to substitute all newlines with " " char, to concatenate the name of all packages in a single line
+# - Use tr to substitute aell newlines with " " char, to concatenate the name of all packages in a single line
+# - Use tr to remove the BOM UTF-8 characters because apk don't like them
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed '1s/^\\xEF\\xBB\\xBF//' | sed ':a;N;$!ba;s/\n/ /g' | xargs -n 1 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr -d '\xEF\xBB\xBF' | sed ':a;N;$!ba;s/\n/ /g' | xargs -n 1 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,9 +43,8 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-#find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\0/g' | xargs -n 1 -r hexdump
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\0/g' | xargs -n 1 -r apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\0/g' | xargs -n 1 -0 -r apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -I {} -t --no-run-if-empty echo "{}"
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -I {} -t --no-run-if-empty apk add "{}"
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -37,14 +37,14 @@ if bashio::config.has_value 'system_packages'; then
 fi
 
 # Install packages specified by the end-user.
-# - Recusively traverse $CONF directory, searching for non-empty system_packages.txt files
+# - Recusively traverse apps directory, searching for non-empty system_packages.txt files
 # - Use cat to read all the file contents, use echo to append whtespace " " char to the file content (to guard against the corner case where the user does not put a newline after the package name)
 # - Use tr to substitute all newlines with " " char, to concatenate the name of all packages in a single line
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-#find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -0 -n 1 -I {} -t --no-run-if-empty apk add "{}"
-echo py3-psycopg2 | xargs apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed 's/\n/ /' | xargs -0 -n 1 -I {} -t --no-run-if-empty echo "{}"
+#echo py3-psycopg2 | xargs apk add
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g' | xargs -0 -n 1 -I {} -t --no-run-if-empty echo "{}"
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/ /g' | xargs -0 -n 1 -I {} -t --no-run-if-empty apk add "{}"
 #echo py3-psycopg2 | xargs apk add
 
 

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;\$!ba;s/\\n/\\x20/g" | xargs -n 1 -0 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ":a;N;\$!ba;s/\\n/\\x20/g" | xargs -n 1 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,9 +43,9 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-packages=`find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\040/g'` | xargs -n 1 -r hexdump
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\040/g' | xargs -n 1 -r hexdump
 
-packages=`find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\040/g'` | xargs -n 1 -r apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed ':a;N;$!ba;s/\n/\040/g' | xargs -n 1 -r apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,8 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty apk -vv add
+#find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -t --no-run-if-empty 
+apk -vv add "py3-psycopg2"
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -43,7 +43,7 @@ fi
 # - Pipe to xargs, printing the executed command (-t), invoking `apk add` with the list of required packages. Do nothing if no system_packages.txt files is present (--no-run-if-empty)
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -n 1 -I {} -t --no-run-if-empty bash -c apk add {}
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | tr '\n' ' ' | xargs -n 1 -I {} -t --no-run-if-empty apk add "{}"
 
 
 # Install user configured/requested Python packages

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,7 +44,7 @@ fi
 mkdir -p /share/appdaemon/apk.cache
 ln -s /share/appdaemon/apk.cache /etc/apk/cache
 
-find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed '1s/^\\xEF\\xBB\\xBF//' | sed ':a;N;\$!ba;s/\n/ /g' | xargs -n 1 -r -t apk add
+find /config/appdaemon -name system_packages.txt -type f -not -empty -exec cat {} \; -exec echo -n " " \; | sed '1s/^\\xEF\\xBB\\xBF//' | sed ':a;N;$!ba;s/\n/ /g' | xargs -n 1 -r -t apk add
 
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then

--- a/repository.json
+++ b/repository.json
@@ -1,0 +1,5 @@
+{
+  "name": "AppDaemon2",
+  "url": "https://github.com/AlexMKX/addon-appdaemon",
+  "maintainer": "Koen Kanters <koenkanters94@gmail.com>"
+}

--- a/repository.json
+++ b/repository.json
@@ -1,0 +1,5 @@
+{
+    "name": "AppDaemon addon",
+    "url": "https://github.com/AlexMKX/addon-appdaemon",
+    "maintainer": "AlexMKX"
+  }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,0 @@
-{
-  "name": "AppDaemon2",
-  "url": "https://github.com/AlexMKX/addon-appdaemon",
-  "maintainer": "Koen Kanters <koenkanters94@gmail.com>"
-}


### PR DESCRIPTION
# Proposed Changes

Porting the original functionality from the AppDaemon's docker image.

This change will consists of the following functionalities:

1.  Auto-installing the system packages from the system_packages.txt, provided by the app.
2.  Auto-installing the python packages from requirements.txt, provided by the app.
_The above functionality will make app installation more straight-forward and unattended (no need to modify config, just checkout or copy files)_
3. Creating the cache for ystem packages and pip packages in /share/appdaemon so AppDaemon addon will start faster and can start without internet connection.

