### PR TITLE
Migrate AppDaemon config out of Home Assistant config folder

### DIFF
--- a/appdaemon/DOCS.md
+++ b/appdaemon/DOCS.md
@@ -92,8 +92,8 @@ single time this add-on starts.
 This add-on does not configure the AppDaemon or HADashboard for you.
 It does, however, create some sample files to get you started on the first run.
 
-The configuration of the AppDaemon can be found in the `/config/appdaemon`
-directory.
+The configuration of the AppDaemon can be found in the add-on configuration
+folder of this add-on.
 
 For more information about configuring AppDaemon, please refer to the
 extensive documentation they offer:

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -18,9 +18,10 @@ ports:
 ports_description:
   5050/tcp: AppDaemon
 map:
-  - config:rw
-  - share:rw
+  - addon_config:rw
+  - homeassistant_config:rw
   - media:rw
+  - share:rw
   - ssl
 options:
   system_packages: []

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -31,4 +31,4 @@ if bashio::config.has_value 'log_level'; then
 fi
 
 # Run the AppDaemon
-exec appdaemon -c /config/appdaemon -D "${log_level}"
+exec appdaemon -c /config -D "${log_level}"

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -5,24 +5,19 @@
 # Configures AppDaemon
 # ==============================================================================
 
-# Creates initial AppDaemon configuration in case it is non-existing
-if ! bashio::fs.directory_exists '/config/appdaemon'; then
-    cp -R /root/appdaemon /config/appdaemon \
-        || bashio::exit.nok 'Failed to create initial AppDaemon configuration'
+# Migrate add-on data from the Home Assistant config folder,
+# to the add-on configuration folder.
+if ! bashio::fs.directory_exists '/config/appdaemon.yaml' \
+    && bashio::fs.file_exists '/homeassistant/appdaemon/appdaemon.yaml'; then
+    shopt -s dotglob
+    mv /homeassistant/appdaemon/* /config/ \
+        || bashio::exit.nok "Failed to migrate AppDaemon configuration"
 fi
 
-# Raise warning if the directory exists, but the appdaemon config is missing.
-if ! bashio::fs.file_exists '/config/appdaemon/appdaemon.yaml'; then
-    bashio::log.fatal
-    bashio::log.fatal "Seems like the /config/appdaemon folder exists,"
-    bashio::log.fatal "however appdaemon.yaml wasn't found."
-    bashio::log.fatal
-    bashio::log.fatal "Remove or rename the /config/appdaemon folder"
-    bashio::log.fatal "and the add-on will create a new and fresh one"
-    bashio::log.fatal "for you."
-    bashio::log.fatal
-
-    bashio::exit.nok
+# Creates initial AppDaemon configuration in case it is non-existing
+if ! bashio::fs.directory_exists '/config/appdaemon.yaml'; then
+    cp -R /root/appdaemon/* /config/ \
+        || bashio::exit.nok 'Failed to create initial AppDaemon configuration'
 fi
 
 # Install user configured/requested packages


### PR DESCRIPTION
# Proposed Changes

This moves the AppDaemon configuration out of the Home Assistant configuration folder, into its own add-on configuration folder. This ensures the AppDaemon configuration is included in the add-on backups as well.

