### PR TITLE
Remove default secrets file from initial AppDaemon configuration

### DIFF
--- a/appdaemon/rootfs/root/appdaemon/appdaemon.yaml
+++ b/appdaemon/rootfs/root/appdaemon/appdaemon.yaml
@@ -1,5 +1,4 @@
 ---
-secrets: /config/secrets.yaml
 appdaemon:
   latitude: 52.379189
   longitude: 4.899431


### PR DESCRIPTION
# Proposed Changes

This isn't needed and by default, it should lean into HA for this.
Fixed a bug where this file doesn't exist when setting up AppDaemon from scratch.

