### PR TITLE
Fix incorrect check if AppDaemon configuration already exists

### DIFF
--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -15,7 +15,7 @@ if ! bashio::fs.directory_exists '/config/appdaemon.yaml' \
 fi
 
 # Creates initial AppDaemon configuration in case it is non-existing
-if ! bashio::fs.directory_exists '/config/appdaemon.yaml'; then
+if ! bashio::fs.file_exists '/config/appdaemon.yaml'; then
     cp -R /root/appdaemon/* /config/ \
         || bashio::exit.nok 'Failed to create initial AppDaemon configuration'
 fi


### PR DESCRIPTION
# Proposed Changes

The AppDaemon existing configuration check changed, however, the method used is checking for a directory, not a file.

This fixes that bug.

Related to #287 

../Frenck