### PR TITLE
Add tip about basepath for File Editor access

### DIFF
--- a/appdaemon/DOCS.md
+++ b/appdaemon/DOCS.md
@@ -32,6 +32,8 @@ this isn't needed.
 
 **Note**: _Remember to restart the add-on when the configuration is changed._
 
+:information_source: In order to edit the configuration using the File Editor add-on, you will need to **disable** the File Editor configuration option "Enforce Basepath"
+
 Example add-on configuration:
 
 ```yaml


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Add note about disabling "Enforce Basepath" in File Editor add-on in order to access this add-on's configuration.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
Helps to mitigate issues like #330
