### PR TITLE
DOCS: Add base config path for addon to docs

### DIFF
--- a/appdaemon/DOCS.md
+++ b/appdaemon/DOCS.md
@@ -30,6 +30,8 @@ this isn't needed.
 
 ## Configuration
 
+Configurations are under `/addon_configs/a0d7b954_appdaemon`
+<br/><br/>
 **Note**: _Remember to restart the add-on when the configuration is changed._
 
 Example add-on configuration:


### PR DESCRIPTION
# Proposed Changes

I assumed the appdaemon.yaml was supposed to be under `/config/appdaemon.yaml`
The add-on also logs `Configuration read from: /config/appdaemon.yaml` when it starts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section detailing the configuration location for the AppDaemon add-on.
	- Clarified the importance of restarting the add-on after configuration modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->