### PR TITLE
Drop support for 32-bits systems

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -100,8 +97,6 @@ SOFTWARE.
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
 [appdaemon]: https://appdaemon.readthedocs.io
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-appdaemon.svg
 [commits]: https://github.com/hassio-addons/addon-appdaemon/commits/main
 [contributors]: https://github.com/hassio-addons/addon-appdaemon/graphs/contributors
@@ -116,7 +111,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-appdaemon/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-appdaemon/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-appdaemon.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/appdaemon/build.yaml
+++ b/appdaemon/build.yaml
@@ -2,7 +2,6 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:17.2.5
   amd64: ghcr.io/hassio-addons/base:17.2.5
-  armv7: ghcr.io/hassio-addons/base:17.2.5
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@frenck.dev

--- a/appdaemon/config.yaml
+++ b/appdaemon/config.yaml
@@ -9,7 +9,6 @@ webui: http://[HOST]:[PORT:5050]
 arch:
   - aarch64
   - amd64
-  - armv7
 init: false
 homeassistant_api: true
 uart: true


### PR DESCRIPTION
# Proposed Changes

Since this is a major release already.

Dropping support for 32-bits systems, following:

https://www.home-assistant.io/blog/2025/05/22/deprecating-core-and-supervised-installation-methods-and-32-bit-systems/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration and documentation to remove support for armhf, armv7, and i386 architectures.
  - Adjusted build settings to only include aarch64 and amd64 architectures.
  - Removed related architecture badges from the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->