### PR TITLE
Patch hass plugin config validation model

### DIFF
--- a/appdaemon/Dockerfile
+++ b/appdaemon/Dockerfile
@@ -27,6 +27,7 @@ RUN \
     \
     && cd /usr/lib/python3.12/site-packages/ \
     && patch -p1 < /patches/force_recompile.patch \
+    && patch -p1 < /patches/plugin_config_model.patch \
     \
     && find /usr \
         \( -type d -a -name test -o -name tests -o -name '__pycache__' \) \

--- a/appdaemon/rootfs/patches/plugin_config_model.patch
+++ b/appdaemon/rootfs/patches/plugin_config_model.patch
@@ -1,0 +1,13 @@
+diff --git a/appdaemon/models/config/plugin.py b/appdaemon/models/config/plugin.py
+index 3fc2d61f..ec39e42e 100644
+--- a/appdaemon/models/config/plugin.py
++++ b/appdaemon/models/config/plugin.py
+@@ -85,7 +85,7 @@ class StartupConditions(BaseModel):
+
+ class HASSConfig(PluginConfig):
+     ha_url: str = "http://supervisor/core"
+-    token: SecretStr
++    token: SecretStr | None = None
+     ha_key: Annotated[SecretStr, deprecated("'ha_key' is deprecated. Please use long lived tokens instead")] | None = None
+     appdaemon_startup_conditions: StartupConditions | None = None
+     plugin_startup_conditions: StartupConditions | None = None


### PR DESCRIPTION
# Proposed Changes

Fixes:

```
[07:20:50] INFO: Starting AppDaemon...
s6-rc: info: service legacy-services successfully started
Configuration error in: /config/appdaemon.yaml
1 validation error for MainConfig
appdaemon.plugins.HASS.hass.token
  Field required [type=missing, input_value={'type': 'hass', 'name': 'HASS'}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.10/v/missing
[07:20:57] INFO: Service AppDaemon exited with code 1 (by signal 0)
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated configuration handling to allow the token field to be optional, improving flexibility for users who do not require a token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->