### PR TITLE
Only migrate HA authentication when HASS plugin is used:

### DIFF
--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -21,15 +21,18 @@ if ! bashio::fs.file_exists '/config/appdaemon.yaml'; then
 fi
 
 # Fix authentication for existing users who don't have token or ha_key configured
-token_exists=$(yq e '.appdaemon.plugins.HASS | has("token")' /config/appdaemon.yaml)
-ha_key_exists=$(yq e '.appdaemon.plugins.HASS | has("ha_key")' /config/appdaemon.yaml)
+hass_plugin_exists=$(yq e 'has("appdaemon") and .appdaemon | has("plugins") and .appdaemon.plugins | has("HASS")' /config/appdaemon.yaml)
+if [[ "$hass_plugin_exists" == "true" ]]; then
+    token_exists=$(yq e '.appdaemon.plugins.HASS | has("token")' /config/appdaemon.yaml)
+    ha_key_exists=$(yq e '.appdaemon.plugins.HASS | has("ha_key")' /config/appdaemon.yaml)
 
-if [[ "$token_exists" == "false" && "$ha_key_exists" == "false" ]]; then
-    bashio::log.info "Updating existing AppDaemon configuration to add authentication token..."
-    
-    # Add the token to the HASS plugin configuration with proper YAML tag
-    yq e '.appdaemon.plugins.HASS.token = "SUPERVISOR_TOKEN" | .appdaemon.plugins.HASS.token tag="!env_var"' -i /config/appdaemon.yaml \
-        || bashio::log.warning "Failed to update AppDaemon configuration with token"
+    if [[ "$token_exists" == "false" && "$ha_key_exists" == "false" ]]; then
+        bashio::log.info "Updating existing AppDaemon configuration to add authentication token..."
+        
+        # Add the token to the HASS plugin configuration with proper YAML tag
+        yq e '.appdaemon.plugins.HASS.token = "SUPERVISOR_TOKEN" | .appdaemon.plugins.HASS.token tag="!env_var"' -i /config/appdaemon.yaml \
+            || bashio::log.warning "Failed to update AppDaemon configuration with token"
+    fi
 fi
     
 current_url=$(yq e '.http.url' /config/appdaemon.yaml)


### PR DESCRIPTION
# Proposed Changes

It turns out, people use AppDaemon without connecting to Home Assistant 😅

This check ensures we only migrate/adjust the configuration if the Home Assistant plugin is actually configured.

fixes https://github.com/AppDaemon/appdaemon/issues/2289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when handling configuration files by ensuring that checks for authentication keys are only performed if the relevant plugin section exists. This prevents potential errors with missing or incomplete configuration sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->