### PR TITLE
Update python version to 3.12.11-r0

### DIFF
--- a/appdaemon/Dockerfile
+++ b/appdaemon/Dockerfile
@@ -16,12 +16,12 @@ COPY rootfs/patches /patches
 RUN \
     apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
-        python3-dev=3.12.10-r1 \
+        python3-dev=3.12.11-r0 \
     \
     && apk add --no-cache \
         py3-pip=24.3.1-r0 \
         py3-wheel=0.43.0-r0 \
-        python3=3.12.10-r1 \
+        python3=3.12.11-r0 \
         yq-go=4.44.5-r5 \
     \
     && pip install -r /tmp/requirements.txt \


### PR DESCRIPTION
# Proposed Changes

Update python and python-dev to 3.12.11-r0, because version 3.12.10-r1 is not available in the Alpine repository anymore.

## Related Issues

Fixes #419 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated underlying Python 3 packages to newer versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->