### PR TITLE
Update Alpine version in Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,7 +25,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_19/{{package}}"
+      "depNameTemplate": "alpine_3_21/{{package}}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
# Proposed Changes

Update the Alpine Linux version in the Renovate config to reflect the actual version of Alpine Linux used. It was set to 3.19, while the base image was updated to 3.21.

## Related Issues

Fixes #419 
Replaces #422 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to track Alpine Linux version 3.21 in Dockerfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->