### PR TITLE
⬆️ Update to base image 21.0.0 (Alpine 3.24)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,7 @@
       ],
       "versioningTemplate": "loose",
       "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "depNameTemplate": "alpine_3_24/{{package}}"
     }
   ],
   "packageRules": [

--- a/appdaemon/Dockerfile
+++ b/appdaemon/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/base:21.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -15,18 +15,18 @@ COPY rootfs/patches /patches
 # hadolint ignore=DL3003,DL3042
 RUN \
     apk add --no-cache --virtual .build-dependencies \
-        build-base=0.5-r3 \
-        python3-dev=3.12.13-r0 \
+        build-base=0.5-r4 \
+        python3-dev=3.14.5-r0 \
     \
     && apk add --no-cache \
-        py3-pip=25.1.1-r1 \
-        py3-wheel=0.46.3-r0 \
-        python3=3.12.13-r0 \
-        yq-go=4.49.2-r5 \
+        py3-pip=26.1.2-r0 \
+        py3-wheel=0.47.0-r0 \
+        python3=3.14.5-r0 \
+        yq-go=4.53.3-r0 \
     \
     && pip install -r /tmp/requirements.txt \
     \
-    && cd /usr/lib/python3.12/site-packages/ \
+    && cd /usr/lib/python3.14/site-packages/ \
     && patch -p1 < /patches/force_recompile.patch \
     \
     && find /usr \

--- a/appdaemon/build.yaml
+++ b/appdaemon/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:20.1.1
-  amd64: ghcr.io/hassio-addons/base:20.1.1
+  aarch64: ghcr.io/hassio-addons/base:21.0.0
+  amd64: ghcr.io/hassio-addons/base:21.0.0


### PR DESCRIPTION
# Proposed Changes

Updates the add-on to the latest add-on base image `21.0.0`, which is based on Alpine `3.24.0`, and pins all `apk`-installed packages to their latest versions for that Alpine release:

- `ghcr.io/hassio-addons/base`: `20.1.1` → `21.0.0` (in both `Dockerfile` and `build.yaml`)
- `build-base`: `0.5-r3` → `0.5-r4`
- `python3-dev`: `3.12.13-r0` → `3.14.5-r0`
- `py3-pip`: `25.1.1-r1` → `26.1.2-r0`
- `py3-wheel`: `0.46.3-r0` → `0.47.0-r0`
- `python3`: `3.12.13-r0` → `3.14.5-r0`
- `yq-go`: `4.49.2-r5` → `4.53.3-r0`
- Updated the hardcoded site-packages path `python3.12` → `python3.14`
- Updated the Renovate Repology tracking from `alpine_3_23` to `alpine_3_24`

> [!WARNING]
> The build does **not** currently pass. Alpine `3.24` ships Python `3.14`, but the add-on pins `appdaemon==4.5.13`, which declares `Requires-Python >=3.10,<3.14`. As a result `pip install` cannot resolve AppDaemon:
>
> ```
> ERROR: Could not find a version that satisfies the requirement appdaemon==4.5.13
> ```
>
> This is an application-level incompatibility rather than a packaging issue, and resolving it (bumping AppDaemon to a Python 3.14 compatible release, or holding back the Python version) needs a decision before this can merge.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container base image to version 21.0.0
  * Upgraded Python runtime from version 3.12 to 3.14
  * Updated build dependencies for enhanced stability and compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->