### PR TITLE
💥 Migrate to Debian base with an app-managed Python runtime

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,33 +20,34 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["//Dockerfile$/"],
-      "matchStringsStrategy": "any",
-      "matchStrings": [
-        "\\s\\s(?<package>[a-z0-9][a-z0-9-_]+)=(?<currentValue>[a-z0-9-_.]+)\\s+"
-      ],
-      "versioningTemplate": "loose",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "alpine_3_23/{{package}}"
+      "matchStrings": ["ARG YQ_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "mikefarah/yq",
+      "versioningTemplate": "loose"
     }
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["github-releases"],
+      "matchDepNames": ["mikefarah/yq"],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
-    },
-    {
-      "groupName": "Python",
-      "matchDatasources": ["repology"],
-      "automerge": true,
-      "matchDepNames": ["/^alpine.*/python.*/"]
-    },
-    {
-      "groupName": "App base image",
-      "matchDatasources": ["docker"]
     },
     {
       "groupName": "App base image",
       "matchDatasources": ["docker"],
+      "matchDepNames": ["ghcr.io/hassio-addons/debian-base"]
+    },
+    {
+      "groupName": "App base image",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["ghcr.io/hassio-addons/debian-base"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["ghcr.io/astral-sh/uv"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },

--- a/appdaemon/DOCS.md
+++ b/appdaemon/DOCS.md
@@ -67,11 +67,21 @@ These log level also affects the log levels of the AppDaemon.
 
 ### Option: `system_packages`
 
-Allows you to specify additional [Alpine packages][alpine-packages] to be
+Allows you to specify additional [Debian packages][debian-packages] to be
 installed to your AppDaemon setup (e.g., `g++`. `make`, `ffmpeg`).
 
 **Note**: _Adding many packages will result in a longer start-up time
 for the app._
+
+**Breaking change**: _This app used to be based on Alpine Linux and this
+option took Alpine package names. It now takes Debian package names, which
+differ for some packages (e.g., `build-base` is now `build-essential`).
+Please check your configured packages against the Debian package list._
+
+If you were using this option to install a Python library (e.g.,
+`py3-numpy`), use the `python_packages` option instead. Python libraries
+installed by Debian are not visible to AppDaemon, and `python_packages` now
+has prebuilt packages available for virtually everything on PyPI.
 
 ### Option: `python_packages`
 
@@ -176,9 +186,9 @@ SOFTWARE.
 
 [addon-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_appdaemon&repository_url=https%3A%2F%2Fgithub.com%2Fhassio-addons%2Frepository
-[alpine-packages]: https://pkgs.alpinelinux.org/packages
 [appdaemon]: https://appdaemon.readthedocs.io
 [contributors]: https://github.com/hassio-addons/app-appdaemon/graphs/contributors
+[debian-packages]: https://packages.debian.org/stable/
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-appdaemon-4/163259?u=frenck

--- a/appdaemon/Dockerfile
+++ b/appdaemon/Dockerfile
@@ -9,7 +9,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV \
     PATH="/opt/appdaemon/bin:${PATH}" \
-    UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_NO_CACHE=1 \
     UV_PYTHON_INSTALL_DIR=/usr/local/share/uv/python \
@@ -36,7 +35,7 @@ RUN \
     \
     && YQ_ARCH="${BUILD_ARCH}" \
     && if [ "${BUILD_ARCH}" = "aarch64" ]; then YQ_ARCH="arm64"; fi \
-    && curl -L -s -o /usr/bin/yq \
+    && curl -fsSL -o /usr/bin/yq \
         "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH}" \
     && chmod a+x /usr/bin/yq \
     \
@@ -48,9 +47,12 @@ RUN \
     && patch -p1 < /patches/force_recompile.patch \
     \
     && find /usr/local/share/uv/python "${VIRTUAL_ENV}" \
-        \( -type d -a \( -name test -o -name tests -o -name idlelib \
-            -o -name tkinter -o -name turtledemo -o -name ensurepip \) \) \
-        -o \( -type f -a \( -name '*.a' -o -name '*.pyc' -o -name '*.pyo' \) \) \
+        \( \
+            \( -type d -a \( -name test -o -name tests -o -name idlelib \
+                -o -name tkinter -o -name turtledemo -o -name ensurepip \
+                -o -name __pycache__ \) \) \
+            -o \( -type f -a \( -name '*.a' -o -name '*.pyc' -o -name '*.pyo' \) \) \
+        \) \
         -exec rm -rf '{}' + \
     \
     && apt-get purge -y --auto-remove patch \

--- a/appdaemon/Dockerfile
+++ b/appdaemon/Dockerfile
@@ -1,9 +1,21 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base:20.1.1
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:9.4.0
+# hadolint ignore=DL3006
+FROM ghcr.io/astral-sh/uv:0.12.7 AS uv
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ENV \
+    PATH="/opt/appdaemon/bin:${PATH}" \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_NO_CACHE=1 \
+    UV_PYTHON_INSTALL_DIR=/usr/local/share/uv/python \
+    VIRTUAL_ENV=/opt/appdaemon
+
+COPY --from=uv /uv /usr/local/bin/uv
 
 # Copy Python requirements file
 COPY requirements.txt /tmp/
@@ -12,35 +24,46 @@ COPY requirements.txt /tmp/
 COPY rootfs/patches /patches
 
 # Setup base
-# hadolint ignore=DL3003,DL3042
+ARG BUILD_ARCH=amd64
+ARG PYTHON_VERSION="3.13"
+ARG YQ_VERSION="v4.53.6"
+# hadolint ignore=DL3003,DL3008
 RUN \
-    apk add --no-cache --virtual .build-dependencies \
-        build-base=0.5-r3 \
-        python3-dev=3.12.13-r0 \
+    apt-get update \
     \
-    && apk add --no-cache \
-        py3-pip=25.1.1-r1 \
-        py3-wheel=0.46.3-r0 \
-        python3=3.12.13-r0 \
-        yq-go=4.49.2-r5 \
+    && apt-get install -y --no-install-recommends \
+        patch \
     \
-    && pip install -r /tmp/requirements.txt \
+    && YQ_ARCH="${BUILD_ARCH}" \
+    && if [ "${BUILD_ARCH}" = "aarch64" ]; then YQ_ARCH="arm64"; fi \
+    && curl -L -s -o /usr/bin/yq \
+        "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH}" \
+    && chmod a+x /usr/bin/yq \
     \
-    && cd /usr/lib/python3.12/site-packages/ \
+    && uv python install "${PYTHON_VERSION}" \
+    && uv venv --python "${PYTHON_VERSION}" "${VIRTUAL_ENV}" \
+    && uv pip install --requirements /tmp/requirements.txt \
+    \
+    && cd "${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/" \
     && patch -p1 < /patches/force_recompile.patch \
     \
-    && find /usr \
-        \( -type d -a -name test -o -name tests -o -name '__pycache__' \) \
-        -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+    && find /usr/local/share/uv/python "${VIRTUAL_ENV}" \
+        \( -type d -a \( -name test -o -name tests -o -name idlelib \
+            -o -name tkinter -o -name turtledemo -o -name ensurepip \) \) \
+        -o \( -type f -a \( -name '*.a' -o -name '*.pyc' -o -name '*.pyo' \) \) \
         -exec rm -rf '{}' + \
     \
-    && apk del --no-cache --purge .build-dependencies
+    && apt-get purge -y --auto-remove patch \
+    && apt-get clean \
+    && rm -fr \
+        /tmp/* \
+        /var/{cache,log}/* \
+        /var/lib/apt/lists/*
 
 # Copy root filesystem
 COPY rootfs /
 
 # Build arguments
-ARG BUILD_ARCH
 ARG BUILD_DATE
 ARG BUILD_DESCRIPTION
 ARG BUILD_NAME

--- a/appdaemon/build.yaml
+++ b/appdaemon/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/base:20.1.1
-  amd64: ghcr.io/hassio-addons/base:20.1.1
+  aarch64: ghcr.io/hassio-addons/debian-base:9.4.0
+  amd64: ghcr.io/hassio-addons/debian-base:9.4.0

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -31,4 +31,4 @@ if bashio::config.has_value 'log_level'; then
 fi
 
 # Run the AppDaemon
-exec appdaemon -c /config -D "${log_level}"
+exec /opt/appdaemon/bin/appdaemon -c /config -D "${log_level}"

--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/init-appdaemon/run
@@ -44,11 +44,11 @@ fi
 
 # Install user configured/requested packages
 if bashio::config.has_value 'system_packages'; then
-    apk update \
-        || bashio::exit.nok 'Failed updating Alpine packages repository indexes'
+    apt-get update \
+        || bashio::exit.nok 'Failed updating Debian packages repository indexes'
 
     for package in $(bashio::config 'system_packages'); do
-        apk add "$package" \
+        apt-get install -y --no-install-recommends "$package" \
             || bashio::exit.nok "Failed installing package ${package}"
     done
 fi
@@ -56,7 +56,7 @@ fi
 # Install user configured/requested Python packages
 if bashio::config.has_value 'python_packages'; then
     for package in $(bashio::config 'python_packages'); do
-        pip3 install "$package" \
+        uv pip install --python /opt/appdaemon/bin/python "$package" \
             || bashio::exit.nok "Failed installing package ${package}"
     done
 fi

--- a/appdaemon/translations/en.yaml
+++ b/appdaemon/translations/en.yaml
@@ -7,7 +7,7 @@ configuration:
   system_packages:
     name: System packages
     description: >-
-      Allows you to specificy a list of additional Alpine Linux packages to be
+      Allows you to specificy a list of additional Debian packages to be
       installed before AppDaemon starts.
   python_packages:
     name: Python packages


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Moves this app off Alpine Linux onto Debian, with the Python runtime shipped by the app itself through `uv` instead of coming from the distribution.

### Why now

`main` does not build at the moment. Alpine 3.23 has moved `python3` to `3.12.14-r0` and `yq-go` to `-r6`, and Alpine drops superseded `-rN` revisions from the repository, so a pinned version becomes unbuildable the moment it is replaced. That happened twice in the same week.

The bigger problem is just ahead. Alpine 3.24 ships Python **3.14**, skipping 3.13 entirely, and the current AppDaemon release (4.5.13, `requires-python >=3.10,<3.14`) cannot be installed on it at all. Upstream has already done the 3.14 work on `dev` (4.5.14 declares `<3.15`), but there has not been a release since January 2026. Shipping our own interpreter means neither Alpine's cadence nor AppDaemon's release cadence can break this app again.

### The `python_packages` problem

This is a separate problem with the same symptom, and it is a musl problem rather than a Python version problem. The long tail of PyPI publishes `manylinux` wheels but no `musllinux` wheels, so `pip install` falls back to building from source inside an image that has no compiler. Users see this, which is why these land here rather than upstream:

```
Running `gcc --version` gave "[Errno 2] No such file or directory: 'gcc'"
error: metadata-generation-failed
note: This is an issue with the package mentioned above, not pip.
```

Six packages a user might plausibly put in `python_packages`, checked for wheel availability on both bases:

| Package | Alpine (musl) | Debian (glibc) |
| --- | --- | --- |
| `numpy`, `pandas`, `lxml`, `psycopg2-binary` | wheel | wheel |
| `scikit-learn` | **no wheel** | wheel |
| `opencv-python-headless` | **no wheel** | wheel |

Neither image ships a compiler. On Debian, `scikit-learn` and `opencv-python-headless` install together in 12.5 seconds. The two `python_packages` examples from our own docs, `PyMySQL` and `Pillow`, install in 40ms.

### What changed

* Base on `ghcr.io/hassio-addons/debian-base:9.4.0`
* Python 3.13 installed with `uv`, decoupled from the distribution release cycle
* AppDaemon runs from a virtual environment at `/opt/appdaemon`
* `python_packages` installs with `uv`, `system_packages` with `apt-get`
* `yq` is fetched from upstream releases, because Debian's `yq` package is the Python jq wrapper and has incompatible syntax
* The Alpine repology pins are gone from the Renovate configuration, replaced with a dedicated `customManagers` entry for `YQ_VERSION`, following the same shape as `BASHIO_VERSION` and `TEMPIO_VERSION` in the base images

`PYTHON_VERSION` deliberately has no Renovate manager. It has to follow AppDaemon's `requires-python` range rather than the newest available release, so that pin stays a human decision.

The s6 scripts call `/opt/appdaemon/bin/...` by absolute path rather than relying on `PATH` propagating through `with-contenv`.

### Breaking change

`system_packages` now takes Debian package names instead of Alpine ones. Some differ, for example `build-base` becomes `build-essential`. Only users who have set this option are affected, and it is documented in `DOCS.md`.

`DOCS.md` also gains a note that a Python library installed through `system_packages` (for example `py3-numpy`) is no longer visible to AppDaemon, and should move to `python_packages`. That option now actually works for these packages, which was the reason people reached for `system_packages` in the first place.

### Cost

The image goes from 140 MB to 339 MB. That splits as 123 MB standalone CPython, 79 MB venv, 53 MB `uv` binary, 14 MB `yq`. I tried dropping `uv` from the runtime and seeding the venv with pip instead, and it came out larger at 345 MB, because `COPY --from` is its own layer so deleting it later frees nothing. Keeping `uv` buys the fast runtime install path and is the better trade.

A variant using Debian's own `python3.13` lands at 243 MB and works fine, if the size matters more than full independence from the distribution. Debian moves every two years rather than every six months, so that is a defensible middle ground.

### Testing

| Check | amd64 | aarch64 |
| --- | --- | --- |
| Build | pass | pass (buildx + qemu) |
| AppDaemon boots, HASS plugin loads, binds 5050 | pass | pass |
| Python version | 3.13.15 | 3.13.15 |
| `force_recompile.patch` applied | pass | pass |
| Image size | 339 MB | 338 MB |

`hadolint`, `shellcheck` and `yamllint` are clean. `markdownlint` reports the same three pre-existing MD013 long URL warnings as `main` and nothing new.

Also verified that the unreleased `dev` branch (4.5.14) installs and boots on Python 3.14.7, so the headroom this buys is real and not theoretical.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

No open issue tracks this directly. It addresses the recurring class of `python_packages` build failures and the periodic Alpine pin breakage.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * System packages now use Debian package names instead of Alpine names; update configurations accordingly.
  * Python libraries installed as system packages are no longer available to AppDaemon. Use `python_packages` instead.

* **Improvements**
  * Updated the AppDaemon runtime to a Debian-based environment with Python 3.13.
  * Improved startup reliability and support for multiple processor architectures.
  * Dependency updates for bundled tools are now managed automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->