### PR TITLE
🐛 Wait for Home Assistant to finish starting

### DIFF
--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -6,6 +6,40 @@
 # ==============================================================================
 declare log_level
 
+# Wait for Home Assistant to have finished starting.
+#
+# AppDaemon connects and authenticates as soon as the Core websocket accepts
+# it, but a subscribe_events sent while Core is still loading integrations
+# times out after 10s and is not retried. AppDaemon then keeps running without
+# ever receiving events, until it is restarted by hand.
+declare -i waited=0
+declare core_state
+while [[ ${waited} -lt 300 ]]; do
+    core_state=$(\
+        curl -s -m 10 \
+            -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
+            "http://supervisor/core/api/config" \
+        | jq -r '.state // empty' \
+    ) || core_state=""
+
+    if [[ "${core_state}" = "running" ]]; then
+        break
+    fi
+
+    if [[ ${waited} -eq 0 ]]; then
+        bashio::log.info \
+            "Waiting for Home Assistant to finish starting..."
+    fi
+
+    sleep 5
+    waited=$((waited + 5))
+done
+
+if [[ "${core_state}" != "running" ]]; then
+    bashio::log.warning \
+        "Home Assistant is not running after ${waited}s, starting anyway..."
+fi
+
 bashio::log.info "Starting AppDaemon..."
 
 # Find the matching Tor log level


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Holds off starting AppDaemon until Home Assistant Core reports that it has finished starting.

### The failure

AppDaemon connects and authenticates as soon as the Core websocket accepts it. During a Home Assistant restart that happens well before Core has finished loading its integrations, so the `subscribe_events` that follows times out and is never retried:

```
INFO  HASS: Connected to Home Assistant 2025.12.5 with aiohttp websocket
INFO  HASS: Authenticated to Home Assistant 2025.12.5
WARN  HASS: Timed out [0:00:10] waiting for request: {'type': 'subscribe_events', 'id': 1}
ERROR HAEventsSubError: -1: Unknown response from subscribe_events:
      {'success': False, 'ad_status': 'TIMEOUT', 'ad_duration': 10.52}
```

AppDaemon stays up after this, but never receives a single event, so every app sits idle until someone restarts the app by hand. That matches every report in #478: it only happens when both start together, and a manual restart always fixes it.

### The fix

Core exposes its own startup state on `/api/config` as `hass.state.value` ([`core_config.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/core_config.py)), which is `starting` while integrations load and `running` once finished. The app now polls that through the Supervisor proxy and waits for `running` before launching AppDaemon.

The wait is bounded at 300 seconds and **fails open**. If Core cannot be reached, or never reports `running`, a warning is logged and AppDaemon starts anyway, which is exactly the behaviour today. This cannot make the app fail to start.

### Testing

Exercised all three paths against a mock Supervisor:

| Scenario | Result |
| --- | --- |
| Core reports `starting` then `running` | waited 15s (3 polls), logged the notice once, then started |
| Supervisor unreachable (bound lowered to 10s for the test) | warned after the bound and started anyway |
| Core already `running` | `waited=0s`, nothing logged, 0.47s total |

The third case is the one that matters for everyone not restarting Home Assistant: the first poll succeeds and the app start is not delayed or made noisier.

Shellcheck clean under the v4 job's options, and the image builds.

### Note on upstream

This is a mitigation, not the real fix. AppDaemon should retry `subscribe_events` rather than raising `HAEventsSubError` and carrying on eventless. The `dev` branch still raises it, and the commit that looked related ([`48a6987`](https://github.com/AppDaemon/appdaemon/commit/48a6987f) "timeout fix", 2026-06-29) turns out to be about `call_service` timeouts, so this is not fixed upstream. Worth an issue there, but this stops people losing their automations in the meantime.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Closes #478

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AppDaemon now waits for Home Assistant to become ready before starting.
  * Added status checks during startup, with progress messaging and a warning if readiness is not reached within five minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->