### PR TITLE
🐛 Fix Core state check never matching, delaying every start by 300s

### DIFF
--- a/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
+++ b/appdaemon/rootfs/etc/s6-overlay/s6-rc.d/appdaemon/run
@@ -19,7 +19,7 @@ while [[ ${waited} -lt 300 ]]; do
         curl -s -m 10 \
             -H "Authorization: Bearer ${SUPERVISOR_TOKEN}" \
             "http://supervisor/core/api/config" \
-        | jq -r '.state // empty' \
+        | jq -r '(.state // empty) | ascii_downcase' 2>/dev/null \
     ) || core_state=""
 
     if [[ "${core_state}" = "running" ]]; then


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Fixes the Core readiness check added in #521, which could never succeed and so delayed every app start by the full 300 second timeout.

### The failure

The wait loop compares the Core state against `running`:

```bash
| jq -r '.state // empty'
...
if [[ "${core_state}" = "running" ]]; then
```

But `/api/config` serializes `CoreState`, and its members are uppercase ([`core.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/core.py)):

```python
class CoreState(enum.Enum):
    not_running = "NOT_RUNNING"
    starting = "STARTING"
    running = "RUNNING"        # <-- what /api/config actually emits
```

`core_config.py` emits it as `"state": self.hass.state.value`, so the endpoint returns `"RUNNING"` and the comparison never matches.

Every start therefore blocked for the full 300 seconds regardless of Core's actual state, then logged the "starting anyway" warning and continued. AppDaemon is not `exec`'d until after the loop, which is why the log in #522 goes completely silent after `Waiting for Home Assistant to finish starting...` and no apps run. The reporter gave up at 3 minutes, twice, comfortably before the 300s bound would have released it.

I confirmed this is not a fallout of the Debian base migration: `curl` and `jq` are both present in `debian-base:9.4.0` (`/usr/bin/curl`, `jq-1.7`).

The reason #521 tested clean is that its mock Supervisor returned the state in lowercase, so the comparison matched there but never against real Core.

### The fix

Normalize with `ascii_downcase` in the `jq` filter. Doing it there rather than at the comparison keeps a single comparison site and stays correct if Core ever changes casing again.

Also dropping `jq`'s stderr. While Core restarts, the Supervisor proxy can return a non-JSON body, and `jq` was writing parse errors into the app log every 5 seconds for the duration of the wait. An unparseable body already falls through to "not running", so that output was pure noise in exactly the logs people paste into issues.

### Testing

Shellcheck clean. Exercised by sourcing the real block out of the run script against a mock `curl`, rather than a copy of it, so the code under test is the shipped code:

| Scenario | Result |
| --- | --- |
| Core already `RUNNING` | starts immediately, `waited=0s`, nothing logged |
| `STARTING` twice, then `RUNNING` | breaks out at 10s, notice logged once |
| Non-JSON proxy replies, then `RUNNING` | recovers, stderr clean |
| Core never reports running | 300s bound, warns, starts anyway |

The first row is the one that matters for everyone not restarting Home Assistant, and it is the row that was broken: that path now costs a single poll instead of 300 seconds.

The bound still fails open, so this cannot make the app fail to start.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Closes #522
Regression from #521

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Home Assistant startup detection by recognizing state values regardless of capitalization.
  * Suppressed nonessential parsing error output during state checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->