### PR TITLE
🐛 Restore pip inside the app virtual environment

### DIFF
--- a/appdaemon/Dockerfile
+++ b/appdaemon/Dockerfile
@@ -40,7 +40,7 @@ RUN \
     && chmod a+x /usr/bin/yq \
     \
     && uv python install "${PYTHON_VERSION}" \
-    && uv venv --python "${PYTHON_VERSION}" "${VIRTUAL_ENV}" \
+    && uv venv --seed --python "${PYTHON_VERSION}" "${VIRTUAL_ENV}" \
     && uv pip install --requirements /tmp/requirements.txt \
     \
     && cd "${VIRTUAL_ENV}/lib/python${PYTHON_VERSION}/site-packages/" \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The migration to Debian with an app-managed Python runtime creates the virtual environment using `uv venv`, which does not seed pip into it. As a result, `pip` and `pip3` disappeared from the environment, and the pip module can no longer be imported.

This broke setups that relied on pip being there, either as a command in `init_commands`, or imported from within an AppDaemon app. The reported case does `from pip._internal.operations.freeze import freeze` in an app, which now fails with `ModuleNotFoundError: No module named 'pip'`.

Aliasing pip to uv would not cover that, since it is a module import and not a command. Seeding the virtual environment restores both: the `pip`, `pip3` and `pip3.13` commands, and the importable pip module, matching the behaviour from before the migration. User requested Python packages keep being installed using uv, which is unaffected by this change.

Verified on a local build of the app:

- `pip`, `pip3` and `pip3.13` are present in `/opt/appdaemon/bin` again.
- `from pip._internal.operations.freeze import freeze` imports and runs.
- `pip install <package>` installs into `/opt/appdaemon/lib/python3.13/site-packages`, so AppDaemon picks it up.
- The image grows from 336 MB to 342 MB.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Reported in https://github.com/hassio-addons/app-appdaemon/issues/522#issuecomment-5467826490

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the application’s Python environment setup by ensuring standard package management tools are available after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->